### PR TITLE
Use "dpkg-architecture -qDEB_HOST_ARCH" to get the target cpu type.

### DIFF
--- a/pp.back.deb
+++ b/pp.back.deb
@@ -85,7 +85,7 @@ pp_deb_munge_description () {
 
 #@ pp_deb_detect_arch: sets pp_deb_arch, pp_deb_arch_std
 pp_deb_detect_arch () {
-   pp_deb_arch=`dpkg --print-architecture`
+   pp_deb_arch=`dpkg-architecture -qDEB_HOST_ARCH`
    pp_deb_arch_std=`uname -m`
 }
 


### PR DESCRIPTION
Previously, polypkg was using "dpkg --print-architecture" which doesn't provide a way to override the result when the gcc build type doesn't match its expectations.  This fixes the package name when building .deb files under RedHat.