### PR TITLE
Newer SUSE uses /etc/os-release

### DIFF
--- a/pp.back.rpm
+++ b/pp.back.rpm
@@ -161,6 +161,8 @@ pp_rpm_detect_distro () {
           /^S[uU]SE LINUX Enterprise Server [0-9]/ { print "sles" $5; exit; }
           /^SuSE SLES-[0-9]/  { print "sles" substr($2,6); exit; }
        ' /etc/SuSE-release`
+    elif test -f /etc/os-release; then
+      pp_rpm_distro="`. /etc/os-release && echo \$ID\$VERSION`"
     elif test -f /etc/pld-release; then
        pp_rpm_distro=`awk '
           /^[^ ]* PLD Linux/ { print "pld" $1; exit; }


### PR DESCRIPTION
SLES 15 lacks the /etc/SuSE-release file and uses /etc/os-release instead.  With this change we can build rpms on SLES 15 without an "unknown distro" warning.