### PR TITLE
Write to a $name.file and $name.uninstall

### DIFF
--- a/pp.back.macos
+++ b/pp.back.macos
@@ -884,12 +884,7 @@ pp_backend_macos_flat () {
     esac
     (cd $pkgdir && /usr/bin/xar $xar_flags -cf "../$name-$version.pkg" *)
 
-    rm -rf $pkgdir/*
     echo "version=$version" > $name.uninstall
-    if [ -f "${name}-${version}.dmg" ]; then
-        rm -f ${name}-${version}.dmg
-    fi
-    hdiutil create -fs HFS+ -srcfolder $pkgdir -volname $name ${name}-${version}.dmg
 }
 
 #@ pp_backend_macos_cleanup(): removes any files created outside $pp_wrkdir


### PR DESCRIPTION
Both of those are needed by our uninstaller to remove files that we installed.
In a previous commit, I modified this file to create a .dmg with the .pkg.  Spent some time figuring out why we were doing this in the first place, but didn't find any answers.  I've removed the .dmg creation from Polypkg since we end up combining all our packages into one and ship that.