### PR TITLE
Unbreak macOS.  The pkg-ref must match the name in the bundle dir.

### DIFF
--- a/pp.back.macos
+++ b/pp.back.macos
@@ -718,7 +718,8 @@ pp_backend_macos_flat () {
 
     # build the flat package layout
     pkgdir=$pp_wrkdir/pkg
-    bundledir=$pp_wrkdir/pkg/$name-${version}.pkg
+    pkgfile=$name-$version.pkg
+    bundledir=$pp_wrkdir/pkg/$pkgfile
     Resources=$pkgdir/Resources
     lprojdir=$Resources/en.lproj
     mkdir $pkgdir $bundledir $Resources $lprojdir ||
@@ -767,7 +768,7 @@ pp_backend_macos_flat () {
 	    <choice id="choice0" title="$name $version">
 	        <pkg-ref id="${pp_macos_bundle_id}"/>
 	    </choice>
-	    <pkg-ref id="${pp_macos_bundle_id}" installKBytes="$size" version="$version" auth="Root">#$name.pkg</pkg-ref>
+	    <pkg-ref id="${pp_macos_bundle_id}" installKBytes="$size" version="$version" auth="Root">#$pkgfile</pkg-ref>
 	</installer-script>
 .
 
@@ -882,7 +883,7 @@ pp_backend_macos_flat () {
         "10.5"*) ;;
 	*)	 xar_flags="$xar_flags --distribution";;
     esac
-    (cd $pkgdir && /usr/bin/xar $xar_flags -cf "../$name-$version.pkg" *)
+    (cd $pkgdir && /usr/bin/xar $xar_flags -cf "../$pkgfile" *)
 
     echo "version=$version" > $name.uninstall
 }


### PR DESCRIPTION
This got broken in 51a4bb0 when the version was added to the
bundle dir but not the pkg-ref in the Distribution XML file.