### PR TITLE
Add native support for systemd in the rpm and deb backends

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ PP_SRCS= \
 	 pp.back.bsd \
 	 pp.back.bsd.svc \
 	 pp.back.bsd.func \
+	 pp.back.systemd.svc \
 	 pp.quest
 
 all: pp pp-stripped check

--- a/pp.back.deb
+++ b/pp.back.deb
@@ -211,9 +211,13 @@ pp_deb_handle_services() {
 		case "\$1" in
 		    configure)
 		        # Install the service links
-		        update-rc.d $svc defaults
-		        _pp_systemd_install $svc
-		        _pp_systemd_enable $svc
+		        _pp_systemd_init
+		        if test -n "\$systemctl_cmd"; then
+		            _pp_systemd_install $svc
+		            _pp_systemd_enable $svc
+		        else
+		            update-rc.d $svc defaults
+		        fi
 		        ;;
 		esac
 .

--- a/pp.back.deb
+++ b/pp.back.deb
@@ -201,8 +201,8 @@ pp_deb_handle_services() {
             pp_load_service_vars $svc
 
             # Create init script and systemd service file (unless they exists)
-            pp_deb_service_make_init_script $svc ||
-		pp_error "could not create init script for service $svc"
+            pp_deb_service_make_service_files $svc ||
+		pp_error "could not create service files for $svc"
 
             #-- append %post code to install the svc
 	    test x"yes" = x"$enable" &&

--- a/pp.back.deb
+++ b/pp.back.deb
@@ -193,45 +193,66 @@ pp_deb_handle_services() {
 
     #-- add service start/stop code
     if test -n "$pp_services"; then
+	#-- append common %post install code
+        pp_systemd_service_install_common >> $pp_wrkdir/%post.run
+        pp_systemd_service_install_enable >> $pp_wrkdir/%post.run
+
         #-- record the uninstall commands in reverse order
         for svc in $pp_services; do
             pp_load_service_vars $svc
 
-            # Create init script (unless one exists)
-            pp_deb_service_make_init_script $svc
+            # Create init script and systemd service file (unless they exists)
+            pp_deb_service_make_init_script $svc ||
+		pp_error "could not create init script for service $svc"
+            pp_systemd_make_service_file $svc ||
+		pp_error "could not create service file for service $svc"
 
             #-- append %post code to install the svc
 	    test x"yes" = x"$enable" &&
             cat<<-. >> $pp_wrkdir/%post.run
+
 		case "\$1" in
 		    configure)
 		        # Install the service links
 		        update-rc.d $svc defaults
+		        _pp_systemd_enable $svc
 		        ;;
 		esac
 .
 
             #-- prepend %preun code to stop svc
             cat<<-. | pp_prepend $pp_wrkdir/%preun.run
+
 		case "\$1" in
 		    remove|deconfigure|upgrade)
 		        # Stop the $svc service
 		        invoke-rc.d $svc stop
+		        _pp_systemd_disable $svc
 		        ;;
 		esac
 .
 
             #-- prepend %postun code to remove service
             cat<<-. | pp_prepend $pp_wrkdir/%postun.run
+
 		case "\$1" in
 		    purge)
 		        # Remove the service links
 		        update-rc.d $svc remove
+		        _pp_systemd_remove $svc
 		        ;;
 		esac
 .
         done
+
+        pp_systemd_service_disable_common | pp_prepend $pp_wrkdir/%preun.run
+        pp_systemd_service_install_common | pp_prepend $pp_wrkdir/%preun.run
         #pp_deb_service_remove_common | pp_prepend $pp_wrkdir/%preun.run
+
+        # Actual systemd service removal is done in %postun.
+        # Otherwise, systemd may pick up the init.d script if it exists.
+        pp_systemd_service_remove_common | pp_prepend $pp_wrkdir/%postun.run
+        pp_systemd_service_install_common | pp_prepend $pp_wrkdir/%postun.run
     fi
 
 }

--- a/pp.back.deb
+++ b/pp.back.deb
@@ -195,7 +195,6 @@ pp_deb_handle_services() {
     if test -n "$pp_services"; then
 	#-- append common %post install code
         pp_systemd_service_install_common >> $pp_wrkdir/%post.run
-        pp_systemd_service_install_enable >> $pp_wrkdir/%post.run
 
         #-- record the uninstall commands in reverse order
         for svc in $pp_services; do
@@ -204,8 +203,6 @@ pp_deb_handle_services() {
             # Create init script and systemd service file (unless they exists)
             pp_deb_service_make_init_script $svc ||
 		pp_error "could not create init script for service $svc"
-            pp_systemd_make_service_file $svc ||
-		pp_error "could not create service file for service $svc"
 
             #-- append %post code to install the svc
 	    test x"yes" = x"$enable" &&
@@ -215,6 +212,7 @@ pp_deb_handle_services() {
 		    configure)
 		        # Install the service links
 		        update-rc.d $svc defaults
+		        _pp_systemd_install $svc
 		        _pp_systemd_enable $svc
 		        ;;
 		esac
@@ -245,14 +243,12 @@ pp_deb_handle_services() {
 .
         done
 
-        pp_systemd_service_disable_common | pp_prepend $pp_wrkdir/%preun.run
-        pp_systemd_service_install_common | pp_prepend $pp_wrkdir/%preun.run
+        pp_systemd_service_remove_common | pp_prepend $pp_wrkdir/%preun.run
         #pp_deb_service_remove_common | pp_prepend $pp_wrkdir/%preun.run
 
         # Actual systemd service removal is done in %postun.
         # Otherwise, systemd may pick up the init.d script if it exists.
         pp_systemd_service_remove_common | pp_prepend $pp_wrkdir/%postun.run
-        pp_systemd_service_install_common | pp_prepend $pp_wrkdir/%postun.run
     fi
 
 }

--- a/pp.back.deb.svc
+++ b/pp.back.deb.svc
@@ -7,6 +7,8 @@ pp_backend_deb_init_svc_vars () {
     stop_runlevels=${pp_deb_default_stop_runlevels-"0 1 6"}     # == lsb default-stop
     svc_description="${pp_deb_default_svc_description}" # == lsb short descr
     svc_process=
+    svc_init_filename="${pp_deb_svc_init_filename}"     # == $svc.init
+    svc_init_filepath="${pp_deb_svc_init_filepath}"     # == /etc/init.d/ by default
 
     lsb_required_start='$local_fs $network'
     lsb_should_start=
@@ -22,8 +24,8 @@ pp_backend_deb_init_svc_vars () {
 #   Does nothing if an /etc/init.d/$svc script exists already.
 #   Otherwise creates an /etc/init.d/$svc script
 pp_deb_service_make_init_script () {
-    local svc=$1
-    local script=/etc/init.d/$svc
+    local svc=${svc_init_filename:-$1}
+    local script="${svc_init_filepath:-"/etc/init.d"}/$svc"
     local out=$pp_destdir$script
     local _process _cmd
 

--- a/pp.back.deb.svc
+++ b/pp.back.deb.svc
@@ -256,4 +256,7 @@ esac
 :
 .
     chmod 755 $out
+
+    # Create systemd service file
+    pp_systemd_make_service_file $svc
 }

--- a/pp.back.deb.svc
+++ b/pp.back.deb.svc
@@ -19,11 +19,11 @@ pp_backend_deb_init_svc_vars () {
     stop_priority=50            #-- stop_priority = 100 - start_priority
 }
 
-#@ pp_deb_service_make_init_script(svc): generates a service init script
+#@ pp_deb_service_make_service_files(svc): generates a service init script
 #   Assumes %service variables have been set before invocation
-#   Does nothing if an /etc/init.d/$svc script exists already.
-#   Otherwise creates an /etc/init.d/$svc script
-pp_deb_service_make_init_script () {
+#   Creates an /etc/init.d/$svc script if one does not already exist.
+#   Also creates a systemd service file for $svc.
+pp_deb_service_make_service_files () {
     local svc=${svc_init_filename:-$1}
     local script="${svc_init_filepath:-"/etc/init.d"}/$svc"
     local out=$pp_destdir$script

--- a/pp.back.rpm
+++ b/pp.back.rpm
@@ -469,8 +469,8 @@ pp_backend_rpm () {
             for svc in $pp_services; do
                 pp_load_service_vars $svc
 
-                pp_rpm_service_make_init_script $svc ||
-		    pp_error "could not create init script for service $svc"
+                pp_rpm_service_make_service_files $svc ||
+		    pp_error "could not create service files for $svc"
 
                 #-- append %post code to install the svc
                 pp_rpm_service_install $svc >> $pp_wrkdir/%post.run

--- a/pp.back.rpm
+++ b/pp.back.rpm
@@ -464,8 +464,6 @@ pp_backend_rpm () {
         #-- add service start/stop code
         if test -n "$pp_services"; then
             pp_rpm_service_install_common >> $pp_wrkdir/%post.run
-            pp_systemd_service_install_common >> $pp_wrkdir/%post.run
-            pp_systemd_service_install_enable >> $pp_wrkdir/%post.run
 
             #-- record the uninstall commands in reverse order
             for svc in $pp_services; do
@@ -473,31 +471,16 @@ pp_backend_rpm () {
 
                 pp_rpm_service_make_init_script $svc ||
 		    pp_error "could not create init script for service $svc"
-		pp_systemd_make_service_file $svc ||
-		    pp_error "could not create service file for service $svc"
 
                 #-- append %post code to install the svc
                 pp_rpm_service_install $svc >> $pp_wrkdir/%post.run
-                pp_systemd_service_install $svc >> $pp_wrkdir/%post.run
 
                 #-- prepend %preun code to uninstall svc
                 # (use files in case vars are modified)
-                pp_systemd_service_disable $svc | pp_prepend $pp_wrkdir/%preun.run
                 pp_rpm_service_remove $svc | pp_prepend $pp_wrkdir/%preun.run
-
-                #-- prepend %postun code to remove svc
-                # (the init script must be removed first or systemd will use it)
-                pp_systemd_service_remove $svc | pp_prepend $pp_wrkdir/%postun.run
             done
 
-            pp_systemd_service_disable_common | pp_prepend $pp_wrkdir/%preun.run
-            pp_systemd_service_install_common | pp_prepend $pp_wrkdir/%preun.run
             pp_rpm_service_remove_common | pp_prepend $pp_wrkdir/%preun.run
-
-            # Actual systemd service removal is done in %postun.
-            # Otherwise, systemd may pick up the init.d script if it exists.
-            pp_systemd_service_remove_common | pp_prepend $pp_wrkdir/%postun.run
-            pp_systemd_service_install_common | pp_prepend $pp_wrkdir/%postun.run
         fi
 
 	# make convenience service groups

--- a/pp.back.rpm
+++ b/pp.back.rpm
@@ -458,27 +458,46 @@ pp_backend_rpm () {
 .
 	done >>$specfile
 
-        #-- NB: we don't put any %prep, %build or %install RPM sections
+        #-- NB: we do not put any %prep, %build or %install RPM sections
 	#   into the spec file.
 
         #-- add service start/stop code
         if test -n "$pp_services"; then
             pp_rpm_service_install_common >> $pp_wrkdir/%post.run
+            pp_systemd_service_install_common >> $pp_wrkdir/%post.run
+            pp_systemd_service_install_enable >> $pp_wrkdir/%post.run
 
             #-- record the uninstall commands in reverse order
             for svc in $pp_services; do
                 pp_load_service_vars $svc
 
-                pp_rpm_service_make_init_script $svc
+                pp_rpm_service_make_init_script $svc ||
+		    pp_error "could not create init script for service $svc"
+		pp_systemd_make_service_file $svc ||
+		    pp_error "could not create service file for service $svc"
 
                 #-- append %post code to install the svc
                 pp_rpm_service_install $svc >> $pp_wrkdir/%post.run
+                pp_systemd_service_install $svc >> $pp_wrkdir/%post.run
 
                 #-- prepend %preun code to uninstall svc
                 # (use files in case vars are modified)
+                pp_systemd_service_disable $svc | pp_prepend $pp_wrkdir/%preun.run
                 pp_rpm_service_remove $svc | pp_prepend $pp_wrkdir/%preun.run
+
+                #-- prepend %postun code to remove svc
+                # (the init script must be removed first or systemd will use it)
+                pp_systemd_service_remove $svc | pp_prepend $pp_wrkdir/%postun.run
             done
+
+            pp_systemd_service_disable_common | pp_prepend $pp_wrkdir/%preun.run
+            pp_systemd_service_install_common | pp_prepend $pp_wrkdir/%preun.run
             pp_rpm_service_remove_common | pp_prepend $pp_wrkdir/%preun.run
+
+            # Actual systemd service removal is done in %postun.
+            # Otherwise, systemd may pick up the init.d script if it exists.
+            pp_systemd_service_remove_common | pp_prepend $pp_wrkdir/%postun.run
+            pp_systemd_service_install_common | pp_prepend $pp_wrkdir/%postun.run
         fi
 
 	# make convenience service groups

--- a/pp.back.rpm.svc
+++ b/pp.back.rpm.svc
@@ -92,12 +92,14 @@ pp_rpm_service_remove_common () {
 #@ pp_rpm_service_install(svc): emit code to install/start a service
 pp_rpm_service_install () {
     echo ""
-    echo "_pp_install_service $1"
-    echo "_pp_systemd_install $1"
-    if test $enable = yes; then
-	echo "_pp_enable_service $1"
-	echo "_pp_systemd_enable $1"
-    fi
+    echo "_pp_systemd_init"
+    echo 'if test -n "$systemctl_cmd"; then'
+    echo "    _pp_systemd_install $1"
+    test $enable = yes && echo "    _pp_systemd_enable $1"
+    echo "else"
+    echo "    _pp_install_service $1"
+    test $enable = yes && echo "    _pp_enable_service $1"
+    echo "fi"
 }
 
 #@ pp_rpm_service_remove(svc): emit code to stop/remove a service

--- a/pp.back.rpm.svc
+++ b/pp.back.rpm.svc
@@ -59,6 +59,7 @@ pp_rpm_service_install_common () {
             fi
         }
 .
+    pp_systemd_service_install_common
 }
 
 #@ pp_rpm_service_remove_common(): emit common code for service removal
@@ -85,21 +86,30 @@ pp_rpm_service_remove_common () {
             fi
         }
 .
+    pp_systemd_service_remove_common
 }
 
 #@ pp_rpm_service_install(svc): emit code to install/start a service
 pp_rpm_service_install () {
+    echo ""
     echo "_pp_install_service $1"
-    test $enable = yes && echo "_pp_enable_service $1"
+    echo "_pp_systemd_install $1"
+    if test $enable = yes; then
+	echo "_pp_enable_service $1"
+	echo "_pp_systemd_enable $1"
+    fi
 }
 
 #@ pp_rpm_service_remove(svc): emit code to stop/remove a service
 pp_rpm_service_remove () {
     cat <<-.
-        if [ "\$1" = "remove" -o "\$1" = "0" ]; then
-            # only remove the service if not upgrade
-            _pp_remove_service $1
-        fi
+
+	if [ "\$1" = "remove" -o "\$1" = "0" ]; then
+	    # only remove the service if not upgrade
+	    _pp_remove_service $1
+	    _pp_systemd_disable $1
+	    _pp_systemd_remove $1
+	fi
 .
 }
 
@@ -432,4 +442,7 @@ pp_rpm_service_make_init_script () {
 
 .
     chmod 755 $out
+
+    # Create systemd service file
+    pp_systemd_make_service_file $svc
 }

--- a/pp.back.rpm.svc
+++ b/pp.back.rpm.svc
@@ -228,13 +228,13 @@ pp_rpm_service_group_make_init_script () {
     chmod 755 $out
 }
 
-#@ pp_rpm_service_make_init_script(svc): generates a service init script
-#   Assumes %service variables have been set before invocation
-#   Does nothing if an /etc/init.d/$svc script exists already.
-#   Otherwise creates an /etc/init.d/$svc script that should work
-#   under both Red Hat's chkconfig and LSB. Because LSB support is sometimes
-#   broken on Red Hat, chkconfig is tried first.
-pp_rpm_service_make_init_script () {
+#@ pp_rpm_service_make_service_files(svc): generates a service init script
+#   Assumes %service variables have been set before invocation.
+#   Creates an /etc/init.d/$svc script if one does not already exist.
+#   The init script should work with both Red Hat's chkconfig and LSB.
+#   LSB support is sometimes broken on Red Hat, so chkconfig is tried first.
+#   Also creates a systemd service file for $svc.
+pp_rpm_service_make_service_files () {
     local svc=${svc_init_filename:-$1}
     local script="${svc_init_filepath:-"/etc/init.d"}/$svc"
     local out=$pp_destdir$script

--- a/pp.back.rpm.svc
+++ b/pp.back.rpm.svc
@@ -87,11 +87,8 @@ pp_rpm_service_remove_common () {
 .
 }
 
-
 #@ pp_rpm_service_install(svc): emit code to install/start a service
 pp_rpm_service_install () {
-    pp_rpm_service_make_init_script $1 >/dev/null ||
-        pp_error "could not create init script for service $1"
     echo "_pp_install_service $1"
     test $enable = yes && echo "_pp_enable_service $1"
 }
@@ -116,6 +113,8 @@ pp_backend_rpm_init_svc_vars () {
     stop_runlevels=${pp_rpm_default_stop_runlevels-"0 1 6"} # == lsb default-stop
     svc_description="${pp_rpm_default_svc_description}" # == lsb short descr
     svc_process=
+    svc_init_filename="${pp_rpm_svc_init_filename}"     # == $svc.init
+    svc_init_filepath="${pp_rpm_svc_init_filepath}"     # == /etc/init.d/ by default
 
     lsb_required_start='$local_fs $network'
     lsb_should_start=
@@ -224,8 +223,8 @@ pp_rpm_service_group_make_init_script () {
 #   under both Red Hat's chkconfig and LSB. Because LSB support is sometimes
 #   broken on Red Hat, chkconfig is tried first.
 pp_rpm_service_make_init_script () {
-    local svc=$1
-    local script=/etc/init.d/$svc
+    local svc=${svc_init_filename:-$1}
+    local script="${svc_init_filepath:-"/etc/init.d"}/$svc"
     local out=$pp_destdir$script
     local _process _cmd _rpmlevels
 

--- a/pp.back.systemd.svc
+++ b/pp.back.systemd.svc
@@ -1,10 +1,13 @@
 #@ pp_systemd_make_service_file(): create systemd service file
 pp_systemd_make_service_file() {
-
     local svc f
 
+    if [ "${pp_systemd_disabled:-false}" = "true" ]; then
+	return
+    fi
+
     svc="$1"
-    f="${pp_systemd_service_dir:-'/opt/quest/libexec/vas'}/$svc.service"
+    f="${pp_systemd_service_dir:-/opt/quest/libexec/vas}/$svc.service"
     pp_add_file_if_missing $f run 644 v || return 0
 
     cat <<. >$pp_destdir$f
@@ -35,7 +38,7 @@ pp_systemd_service_init_common () {
     cat <<.
 
         _pp_systemd_init () {
-	    systemd_service_dir=${pp_systemd_service_dir:-'/opt/quest/libexec/vas'}
+	    systemd_service_dir=${pp_systemd_service_dir:-/opt/quest/libexec/vas}
             systemd_target=${pp_systemd_system_target:-"multi-user.target"}
             systemd_target_wants="\${systemd_target}.wants"
 
@@ -79,6 +82,25 @@ pp_systemd_service_init_common () {
 
 #@ pp_systemd_service_install_common(): emit common code for service install
 pp_systemd_service_install_common () {
+    if [ "${pp_systemd_disabled:-false}" = "true" ]; then
+	cat<<'.'
+
+        # systemd support disabled
+        _pp_systemd_init () {
+            return
+        }
+
+        _pp_systemd_install () {
+            return
+        }
+
+        _pp_systemd_enable () {
+            return
+        }
+.
+	return
+    fi
+
     pp_systemd_service_init_common
 
     cat<<'.'
@@ -146,6 +168,25 @@ pp_systemd_service_install_common () {
 
 #@ pp_systemd_service_remove_common(): emit common code for service removal
 pp_systemd_service_remove_common () {
+    if [ "${pp_systemd_disabled:-false}" = "true" ]; then
+	cat<<'.'
+
+        # systemd support disabled
+        _pp_systemd_init () {
+            return
+        }
+
+        _pp_systemd_disable () {
+            return
+        }
+
+        _pp_systemd_remove () {
+            return
+        }
+.
+	return
+    fi
+
     pp_systemd_service_init_common
 
     cat<<'.'

--- a/pp.back.systemd.svc
+++ b/pp.back.systemd.svc
@@ -197,35 +197,3 @@ pp_systemd_service_remove_common () {
         }
 .
 }
-
-#@ pp_systemd_service_install(svc): emit code to install/start a service
-pp_systemd_service_install () {
-cat <<.
-
-    _pp_systemd_enable $1
-.
-}
-
-#@ pp_systemd_service_disable(svc): emit code to stop a service
-pp_systemd_service_disable () {
-cat <<.
-
-    # XXX - this only makes sense for rpm, not deb
-    if [ "\$1" = "remove" -o "\$1" = "0" ]; then
-        # only remove the systemd service if not upgrade
-        _pp_systemd_disable $1
-    fi
-.
-}
-
-#@ pp_systemd_service_remove(svc): emit code to remove a service
-pp_systemd_service_remove () {
-cat <<.
-
-    # XXX - this only makes sense for rpm, not deb
-    if [ "\$1" = "remove" -o "\$1" = "0" ]; then
-        # only remove the systemd service if not upgrade
-        _pp_systemd_remove $1
-    fi
-.
-}

--- a/pp.back.systemd.svc
+++ b/pp.back.systemd.svc
@@ -1,0 +1,220 @@
+#@ pp_systemd_make_service_file(): create systemd service file
+pp_systemd_make_service_file() {
+
+    local svc f
+
+    svc="$1"
+    f="${pp_systemd_service_dir:-'/opt/quest/libexec/vas'}/$svc.service"
+    pp_add_file_if_missing $f || return 0
+
+    cat <<. >$pp_destdir$f
+# Systemd unit file for $svc
+
+[Unit]
+Description=${pp_systemd_service_description:-"systemd service file for $svc"}
+${pp_systemd_service_man:+"Documentation=$pp_systemd_service_man"}
+${pp_systemd_service_documentation:+"Documentation=$pp_systemd_service_documentation"}
+${pp_systemd_service_requires:+"Requires=$pp_systemd_service_requires"}
+After=${pp_systemd_service_after:-"syslog.target network.target auditd.service"}
+${pp_systemd_service_before:+"Before=$pp_systemd_service_before"}
+${pp_systemd_service_wants:+"Wants=$pp_systemd_service_wants"}
+${pp_systemd_service_conflicts:+"Conflicts=$pp_systemd_service_conflicts"}
+
+[Service]
+ExecStart=${pp_systemd_service_exec:-"/opt/quest/sbin/$svc"} ${pp_systemd_service_exec_args}
+KillMode=${pp_systemd_service_killmode:-process}
+Type=${pp_systemd_service_type:-forking}
+
+[Install]
+WantedBy=${pp_systemd_system_target:-"multi-user.target"}
+.
+}
+
+#@ pp_systemd_service_install_common(): emit common code for install/uninstall
+pp_systemd_service_install_common () {
+    cat <<.
+
+        _pp_systemd_init () {
+	    systemd_service_dir=${pp_systemd_service_dir:-'/opt/quest/libexec/vas'}
+            systemd_target=${pp_systemd_system_target:-"multi-user.target"}
+            systemd_target_wants="\${systemd_target}.wants"
+
+            pkg_config_cmd=${pp_systemd_pkg_config_cmd:-"\$(command -v pkg-config)"}
+            systemctl_cmd=${pp_systemd_systemctl_cmd:-"\$(command -v systemctl)"}
+
+            # See if pkg-config is installed to get the default locations for this OS, if not installed then just use what we hard code.
+            # So far works on Debian 8, OpenSuse12.3, Ubuntu 16.04, RHEL 7.3
+            # See systemd wiki for more OS interactions https://en.wikipedia.org/wiki/Systemd
+            if [ -x "\$pkg_config_cmd" ]; then
+                systemd_system_unit_dir="\$(pkg-config systemd --variable=systemdsystemunitdir)"
+                systemd_system_conf_dir="\$(pkg-config systemd --variable=systemdsystemconfdir)"
+            fi
+
+            #if pkg-config does not exist or if the \$pkg_config_cmd command returns nothing
+            if test -z "\$systemd_system_unit_dir"; then
+              systemdsystemunitdirs="/lib/systemd/system /usr/lib/systemd/system"
+              for dir in \$systemdsystemunitdirs; do
+                  if [ -d "\$dir/\$systemd_target_wants" ]; then
+                    systemd_system_unit_dir="\$dir"
+                    break
+                  fi
+              done
+            fi
+
+            # In the case where \$systemd_system_conf_dir is empty hard code the path
+            if test -z "\$systemd_system_conf_dir"; then
+                systemd_system_conf_dir="/etc/systemd/system"
+            fi
+
+            # if the \$svc.pp file defines the systemd unit dir then use it.
+            ${pp_systemd_system_unit_dir:+"# systemd_system_unit_dir defined by variable pp_systemd_system_unit_dir from the \$svc.pp file"}
+            systemd_system_unit_dir="${pp_systemd_system_unit_dir:-"\$systemd_system_unit_dir"}"
+
+            # if the \$svc.pp file defines the systemd conf dir then use it.
+            ${pp_systemd_system_conf_dir:+"# systemd_system_conf_dir defined by variable pp_systemd_system_conf_dir from the \$svc.pp file"}
+            systemd_system_conf_dir="${pp_systemd_system_conf_dir:-"\$systemd_system_conf_dir"}"
+        }
+.
+}
+
+#@ pp_systemd_service_install_enable(): emit common code to enable a service
+pp_systemd_service_install_enable () {
+    cat<<'.'
+
+        _pp_systemd_enable () {
+            local svc="$1"
+            local RUNNING
+
+            # If $systemctl_cmd is not set, then call _pp_systemd_init. If still not
+            # set, we do not know where the systemctl command is so do nothing;
+            # systemd must not be on this system.
+            if test -z "$systemctl_cmd"; then
+                _pp_systemd_init
+            fi
+
+            if test -x "$systemctl_cmd" && test -d $systemd_system_conf_dir/$systemd_target_wants; then
+                # If our service file still exists (upgrade) remove the link/file and systemctl
+                # will recreate it if/when we enable the $svc service.
+                rm -f "$systemd_system_conf_dir/$systemd_target_wants/$svc.service"
+
+                # Copy the $svc.service file to the correct systemd_system_unit_dir location
+                if [ "x$systemd_service_dir" != "x$systemd_system_unit_dir" ]; then
+                    cp -f "$systemd_service_dir/$svc.service" "$systemd_system_unit_dir/$svc.service"
+                    chmod 644 "$systemd_system_unit_dir/$svc.service"
+                fi
+
+                # stop the daemon using the old init script before enabling systemd for the service
+                # we do this so we do not "orphan" the process. Because init started it and if we enable systemd
+                # it will not know about this process and will not be able to stop it.
+                if [ -x "/etc/init.d/$svc" ]; then
+                    /etc/init.d/$svc status > /dev/null 2>&1
+                    RUNNING=$?
+                    if [ $RUNNING -eq 0 ]; then
+                        /etc/init.d/$svc stop > /dev/null 2>&1
+                    fi
+                else
+                    RUNNING=1
+                fi
+
+                # Enable the $svc.service
+                $systemctl_cmd daemon-reload >/dev/null 2>&1
+                $systemctl_cmd enable $svc.service >/dev/null 2>&1
+
+                # Now that the service has been enabled, start it again if it was running before.
+                if [ $RUNNING -eq 0 ]; then
+                    /etc/init.d/$svc start > /dev/null 2>&1
+                fi
+            fi
+        }
+.
+}
+
+#@ pp_systemd_service_disable_common(): emit common code to disable service
+pp_systemd_service_disable_common () {
+    cat<<'.'
+
+        _pp_systemd_disable () {
+            local svc="$1"
+
+            # If $systemctl_cmd is not set, then call _pp_systemd_init.
+            # If still not set, we do not know where the systemctl command
+            # is so do nothing; systemd must not be on this system.
+            if test -z "$systemctl_cmd"; then
+                _pp_systemd_init
+            fi
+
+            systemd_service_file="$systemd_system_conf_dir/$systemd_target_wants/$svc.service"
+
+            # Remove systemd symlink (enabled) unit service file
+            if test -e $systemd_service_file; then
+                # Disable the $svc service
+                if test -x "$systemctl_cmd"; then
+                    $systemctl_cmd disable $svc.service > /dev/null 2>&1
+                else
+                    # For some reason systemctl is not install but our service file exists
+                    # Just delete the symlink then
+                    rm -f "$systemd_service_file"
+                fi
+            fi
+        }
+.
+}
+
+#@ pp_systemd_service_remove_common(): emit common code for service removal
+pp_systemd_service_remove_common () {
+    cat<<'.'
+
+        _pp_systemd_remove () {
+            local svc="$1"
+
+            # If $systemctl_cmd is not set, then call _pp_systemd_init.
+            # If still not set, we do not know where the systemctl command
+            # is so do nothing; systemd must not be on this system.
+            if test -z "$systemctl_cmd"; then
+                _pp_systemd_init
+            fi
+
+            # Remove the systemd unit service file
+            if [ "x$systemd_service_dir" != "x$systemd_system_unit_dir" ]; then
+                rm -f "$systemd_system_unit_dir/$svc.service"
+            fi
+
+            if test -x "$systemctl_cmd"; then
+                $systemctl_cmd daemon-reload
+                $systemctl_cmd reset-failed $svc.service >/dev/null 2>&1 || true
+            fi
+        }
+.
+}
+
+#@ pp_systemd_service_install(svc): emit code to install/start a service
+pp_systemd_service_install () {
+cat <<.
+
+    _pp_systemd_enable $1
+.
+}
+
+#@ pp_systemd_service_disable(svc): emit code to stop a service
+pp_systemd_service_disable () {
+cat <<.
+
+    # XXX - this only makes sense for rpm, not deb
+    if [ "\$1" = "remove" -o "\$1" = "0" ]; then
+        # only remove the systemd service if not upgrade
+        _pp_systemd_disable $1
+    fi
+.
+}
+
+#@ pp_systemd_service_remove(svc): emit code to remove a service
+pp_systemd_service_remove () {
+cat <<.
+
+    # XXX - this only makes sense for rpm, not deb
+    if [ "\$1" = "remove" -o "\$1" = "0" ]; then
+        # only remove the systemd service if not upgrade
+        _pp_systemd_remove $1
+    fi
+.
+}

--- a/pp.back.systemd.svc
+++ b/pp.back.systemd.svc
@@ -5,7 +5,7 @@ pp_systemd_make_service_file() {
 
     svc="$1"
     f="${pp_systemd_service_dir:-'/opt/quest/libexec/vas'}/$svc.service"
-    pp_add_file_if_missing $f || return 0
+    pp_add_file_if_missing $f run 644 v || return 0
 
     cat <<. >$pp_destdir$f
 # Systemd unit file for $svc

--- a/pp.back.systemd.svc
+++ b/pp.back.systemd.svc
@@ -30,8 +30,8 @@ WantedBy=${pp_systemd_system_target:-"multi-user.target"}
 .
 }
 
-#@ pp_systemd_service_install_common(): emit common code for install/uninstall
-pp_systemd_service_install_common () {
+#@ pp_systemd_service_init_common(): emit common code for install/uninstall
+pp_systemd_service_init_common () {
     cat <<.
 
         _pp_systemd_init () {
@@ -77,9 +77,34 @@ pp_systemd_service_install_common () {
 .
 }
 
-#@ pp_systemd_service_install_enable(): emit common code to enable a service
-pp_systemd_service_install_enable () {
+#@ pp_systemd_service_install_common(): emit common code for service install
+pp_systemd_service_install_common () {
+    pp_systemd_service_init_common
+
     cat<<'.'
+
+        _pp_systemd_install () {
+            local svc="$1"
+
+            # If $systemctl_cmd is not set, then call _pp_systemd_init. If still not
+            # set, we do not know where the systemctl command is so do nothing;
+            # systemd must not be on this system.
+            if test -z "$systemctl_cmd"; then
+                _pp_systemd_init
+            fi
+
+            if test -x "$systemctl_cmd" && test -d "$systemd_system_conf_dir/$systemd_target_wants"; then
+                # If our service file still exists (upgrade) remove the link/file and systemctl
+                # will recreate it if/when we enable the $svc service.
+                rm -f "$systemd_system_conf_dir/$systemd_target_wants/$svc.service"
+
+                # Copy the $svc.service file to the correct systemd_system_unit_dir location
+                if [ "x$systemd_service_dir" != "x$systemd_system_unit_dir" ]; then
+                    cp -f "$systemd_service_dir/$svc.service" "$systemd_system_unit_dir/$svc.service"
+                    chmod 644 "$systemd_system_unit_dir/$svc.service"
+                fi
+            fi
+        }
 
         _pp_systemd_enable () {
             local svc="$1"
@@ -92,17 +117,7 @@ pp_systemd_service_install_enable () {
                 _pp_systemd_init
             fi
 
-            if test -x "$systemctl_cmd" && test -d $systemd_system_conf_dir/$systemd_target_wants; then
-                # If our service file still exists (upgrade) remove the link/file and systemctl
-                # will recreate it if/when we enable the $svc service.
-                rm -f "$systemd_system_conf_dir/$systemd_target_wants/$svc.service"
-
-                # Copy the $svc.service file to the correct systemd_system_unit_dir location
-                if [ "x$systemd_service_dir" != "x$systemd_system_unit_dir" ]; then
-                    cp -f "$systemd_service_dir/$svc.service" "$systemd_system_unit_dir/$svc.service"
-                    chmod 644 "$systemd_system_unit_dir/$svc.service"
-                fi
-
+            if test -x "$systemctl_cmd" && test -f "$systemd_system_unit_dir/$svc.service"; then
                 # stop the daemon using the old init script before enabling systemd for the service
                 # we do this so we do not "orphan" the process. Because init started it and if we enable systemd
                 # it will not know about this process and will not be able to stop it.
@@ -129,8 +144,10 @@ pp_systemd_service_install_enable () {
 .
 }
 
-#@ pp_systemd_service_disable_common(): emit common code to disable service
-pp_systemd_service_disable_common () {
+#@ pp_systemd_service_remove_common(): emit common code for service removal
+pp_systemd_service_remove_common () {
+    pp_systemd_service_init_common
+
     cat<<'.'
 
         _pp_systemd_disable () {
@@ -157,12 +174,6 @@ pp_systemd_service_disable_common () {
                 fi
             fi
         }
-.
-}
-
-#@ pp_systemd_service_remove_common(): emit common code for service removal
-pp_systemd_service_remove_common () {
-    cat<<'.'
 
         _pp_systemd_remove () {
             local svc="$1"


### PR DESCRIPTION
The systemd support was ported from the QAS pp with changes to support deb packages.  Unlike the QAS version, the systemd service code is called via the rpm and deb svc code, not directly from the backends.  This makes it easier to prevent systemd from picking up the old-style init.d script at remove time for instance.