### PR TITLE
Fix Solaris services where the manifest file live outside /var/svc/manifest

### DIFF
--- a/pp.back.solaris.svc
+++ b/pp.back.solaris.svc
@@ -413,11 +413,15 @@ pp_solaris_remove_service () {
 if [ "x${PKG_INSTALL_ROOT}" = 'x' ]; then
     if [ -x /usr/sbin/svcadm ] ; then
         /usr/sbin/svcadm disable -s '$svc' 2>/dev/null
-        if [ `uname -r` = 5.10 ]; then
-          /usr/sbin/svccfg delete '$svc' 2>/dev/null
-        else
-          /usr/sbin/svcadm restart manifest-import 2>/dev/null
-        fi
+	case "`uname -r`-$pp_svc_xml_file" in
+	  5.1[1-9]*-/var/svc/manifest/*|5.[2-9]*-/var/svc/manifest/*)
+	    # Use manifest-import if > 5.10 and manifest in default location
+	    /usr/sbin/svcadm restart manifest-import 2>/dev/null
+	    ;;
+	  *)
+	    /usr/sbin/svccfg delete '$svc' 2>/dev/null
+	    ;;
+	esac
     else
         '$file' stop >/dev/null 2>/dev/null
     fi
@@ -439,11 +443,15 @@ pp_solaris_install_service () {
     echo '
 if [ "x${PKG_INSTALL_ROOT}" != "x" ]; then
   if [ -x ${PKG_INSTALL_ROOT}/usr/sbin/svcadm ]; then
-    if [ `uname -r` = 5.10 ]; then
-      echo "/usr/sbin/svccfg import '$pp_svc_xml_file' 2>/dev/null" >> ${PKG_INSTALL_ROOT}/var/svc/profile/upgrade
-    else
-      echo "/usr/sbin/svcadm restart manifest-import 2>/dev/null" >> ${PKG_INSTALL_ROOT}/var/svc/profile/upgrade
-    fi
+    case "`uname -r`-$pp_svc_xml_file" in
+      5.1[1-9]*-/var/svc/manifest/*|5.[2-9]*-/var/svc/manifest/*)
+	# Use manifest-import if > 5.10 and manifest in default location
+	echo "/usr/sbin/svcadm restart manifest-import 2>/dev/null" >> ${PKG_INSTALL_ROOT}/var/svc/profile/upgrade
+	;;
+      *)
+	echo "/usr/sbin/svccfg import '$pp_svc_xml_file' 2>/dev/null" >> ${PKG_INSTALL_ROOT}/var/svc/profile/upgrade
+	;;
+    esac
   else'
     test -n "${solaris_sysv_init_start_states}" &&
         for state in ${solaris_sysv_init_start_states}; do
@@ -465,26 +473,30 @@ else
     if [ -x /usr/sbin/svcadm ]; then
         echo "Registering '$svc' with SMF"
         /usr/sbin/svcadm disable -s '$svc' 2>/dev/null
-        if [ `uname -r` = 5.10 ]; then
-          /usr/sbin/svccfg delete '$svc' 2>/dev/null
-          /usr/sbin/svccfg import '$pp_svc_xml_file'
-        else
-          /usr/sbin/svcadm restart manifest-import
-          # Wait for import to complete, otherwise it will not know
-          # about our service until after we try to start it
-          echo Waiting for manifest-import...
-          typeset waited
-          waited=0
-          while [ $waited -lt 15 ] && ! /usr/bin/svcs -l '$svc' >/dev/null 2>&1; do
-              sleep 1
-              waited=`expr $waited + 1`
-          done
-          if /usr/bin/svcs -l '$svc' >/dev/null 2>&1; then
-              echo OK
-          else
-              echo manifest-import took to long, you might have to control '$svc' manually.
-          fi
-        fi
+	case "`uname -r`-$pp_svc_xml_file" in
+	  5.1[1-9]*-/var/svc/manifest/*|5.[2-9]*-/var/svc/manifest/*)
+	    # Use manifest-import if > 5.10 and manifest in default location
+	    /usr/sbin/svcadm restart manifest-import
+	    # Wait for import to complete, otherwise it will not know
+	    # about our service until after we try to start it
+	    echo Waiting for manifest-import...
+	    typeset waited
+	    waited=0
+	    while [ $waited -lt 15 ] && ! /usr/bin/svcs -l '$svc' >/dev/null 2>&1; do
+		sleep 1
+		waited=`expr $waited + 1`
+	    done
+	    if /usr/bin/svcs -l '$svc' >/dev/null 2>&1; then
+		echo OK
+	    else
+		echo manifest-import took to long, you might have to control '$svc' manually.
+	    fi
+	    ;;
+	  *)
+	    /usr/sbin/svccfg delete '$svc' 2>/dev/null
+	    /usr/sbin/svccfg import '$pp_svc_xml_file'
+	    ;;
+	esac
     else'
     test -n "${solaris_sysv_init_start_states}" &&
         for state in ${solaris_sysv_init_start_states}; do


### PR DESCRIPTION
The Solaris SMF service manifests can be located anywhere in the file system.  However, only manifest files stored in /var/svc/manifest will be found by "manifest-import".  We need to check the path and fall back to the old scheme if the manifest is not located in the standard directory.