### PR TITLE
Added new systemd variable pp_systemd_service_pidfile for setting PID…

### DIFF
--- a/pp.back.systemd.svc
+++ b/pp.back.systemd.svc
@@ -27,6 +27,7 @@ ${pp_systemd_service_conflicts:+"Conflicts=$pp_systemd_service_conflicts"}
 ExecStart=${pp_systemd_service_exec:-"/opt/quest/sbin/$svc"} ${pp_systemd_service_exec_args}
 KillMode=${pp_systemd_service_killmode:-process}
 Type=${pp_systemd_service_type:-forking}
+${pp_systemd_service_pidfile:+"PIDFile=$pp_systemd_service_pidfile"}
 
 [Install]
 WantedBy=${pp_systemd_system_target:-"multi-user.target"}


### PR DESCRIPTION
…File. When setting Service Type to Simple, for some reason systemd needs PIDFile to be set as well even though it doesn't use it, or create a PIDFile