### PR TITLE
Fix parsing of /etc/redhat-release on RHEL 8.

### DIFF
--- a/pp.back.rpm
+++ b/pp.back.rpm
@@ -146,12 +146,11 @@ pp_rpm_detect_distro () {
           /^Fedora release/ { print "f" $3; exit; }
        ' /etc/fedora-release`
     elif test -f /etc/redhat-release; then
-       pp_rpm_distro=`awk '
-          /^Red Hat Enterprise Linux/ { print "rhel" $7; exit; }
-          /^CentOS release/           { print "centos" $3; exit; }
-          /^CentOS Linux release/     { print "centos" $4; exit; }
-          /^Red Hat Linux release/    { print "rh" $5; exit; }
-       ' /etc/redhat-release`
+       pp_rpm_distro=`sed -n \
+         -e 's/^Red Hat Linux.*release \([0-9][0-9\.]*\).*/rh\1/p' \
+         -e 's/^Red Hat Enterprise Linux.*release \([0-9][0-9\.]*\).*/rhel\1/p' \
+         -e 's/^CentOS.*release \([0-9][0-9\.]*\).*/centos\1/p' \
+       /etc/redhat-release`
     elif test -f /etc/SuSE-release; then
        pp_rpm_distro=`awk '
           /^SuSE Linux [0-9]/ { print "suse" $3; exit; }


### PR DESCRIPTION
RedHat dropped the "server" word from the name in redhat-release which results in the awk script printing the wrong field.
Instead of using awk, just use sed to pull out the version number immediately following the word "release".