### PR TITLE
Fix probe for macOS Big Sur

### DIFF
--- a/pp.back.macos
+++ b/pp.back.macos
@@ -877,7 +877,7 @@ pp_backend_macos_flat () {
     test -d $pp_wrkdir/bom_stage && $pp_macos_sudo rm -rf $pp_wrkdir/bom_stage
 
     # Create the flat package with xar (like pkgutil --flatten does)
-    # Note that --distribution is only supported by Mac OS X 10.6 and above
+    # Note that --distribution is only supported by macOS 10.6 and above
     xar_flags="--compression=bzip2 --no-compress Scripts --no-compress Payload"
     case $mac_version in
         "10.5"*) ;;
@@ -1082,6 +1082,7 @@ pp_macos_add_service () {
 pp_backend_macos_probe () {
     typeset name vers arch
     case `sw_vers -productName` in
+         "macOS")    name="macos";;
          "Mac OS X") name="macos";;
 	 *)          name="unknown";;
     esac


### PR DESCRIPTION
"sw_vers -productName" now returns "macOS", not "Mac OS X"