### PR TITLE
Format the macOS minor version number with two digits.

### DIFF
--- a/pp.back.macos
+++ b/pp.back.macos
@@ -1086,7 +1086,7 @@ pp_backend_macos_probe () {
          "Mac OS X") name="macos";;
 	 *)          name="unknown";;
     esac
-    vers=`sw_vers -productVersion | sed -e 's/^\([^.]*\)\.\([^.]*\).*/\1\2/'`
+    vers=`sw_vers -productVersion | awk -F. '{ printf "%d%02d\n", $1, $2 }'`
     arch=`arch`
     echo "$name$vers-$arch"
 }


### PR DESCRIPTION
This way we get consistent 4-digit version numbers even for macOS verions like 10.3 or 11.0 where the minor number is a single digit.  For example. 10.3 will be formatted as 1003 and 11.0 will be 1100.