### PR TITLE
Solaris 11.4 removed /usr/bin/optisa, use /usr/bin/isainfo instead.

### DIFF
--- a/pp.back.solaris
+++ b/pp.back.solaris
@@ -91,7 +91,11 @@ pp_solaris_detect_os () {
 #   sparc   = 32-bit sparc (sparc)
 #   sparcv9 = 64-bit sparc (sparc64)
 pp_solaris_detect_arch () {
-	pp_solaris_arch=`/usr/bin/optisa amd64 sparcv9 i386 sparc`
+	if [ -x /usr/bin/isainfo ]; then
+	    pp_solaris_arch=`/usr/bin/isainfo -n`
+	else
+	    pp_solaris_arch=`/usr/bin/optisa amd64 sparcv9 i386 sparc`
+	fi
 	[ -z "$pp_solaris_arch" ] &&
 	    pp_error "can't determine processor architecture"
 	case "$pp_solaris_arch" in


### PR DESCRIPTION
As per https://www.oracle.com/solaris/technologies/end-of-feature-notices-solaris11.html the /usr/bin/optisa command no longer exists on Solaris.  We should use /usr/bin/isainfo instead.