### PR TITLE
Put /dev, /etc, /sbin or /var in ROOT, all else in USR.

### DIFF
--- a/pp.back.aix
+++ b/pp.back.aix
@@ -82,17 +82,15 @@ pp_aix_version_fix () {
 }
 
 #@ pp_aix_select(-user|-root) < file-list:
-#   Selects out the %files lines that are in /usr or /opt (-user)
-#   or otherwise (-root).
+#   Selects out the %files lines that are in /dev, /etc, /sbin or /var (-root)
+#   or otherwise (-user).
 pp_aix_select () {
 	case "$1" in
-	    -user) op="";;
-	    -root) op="!";;
+	    -user) op="!";;
+	    -root) op="";;
 	    *) pp_die "pp_aix_select: bad argument";;
 	esac
-	#pp_debug awk '$5 '$op' /^\/(usr|opt)(\/|$)/ { print; }'
-	#awk '$5 '$op' /^\/(usr|opt)(\/|$)/ { print; }'
-	awk $op'($6 ~ /^\/usr\// || $6 ~ /^\/opt\//) { print; }'
+	awk $op'($6 ~ /^\/(dev|etc|sbin|var)\//) { print }'
 }
 
 #@ pp_aix_copy_root($root) < root-file-list:


### PR DESCRIPTION
Only files that cannot be shared between machines belong in ROOT.  Previously, /usr and /opt were placed in USR and everything else went in ROOT.  Now, only /dev, /etc, /sbin and /var go in ROOT. This fixes a failure when pp runs the backup program if the package specifies a non-standard location such as /local that would otherwise be included in ROOT.