### PR TITLE
Add support for background images and update some obsolete distribution settings

### DIFF
--- a/pp.back.macos
+++ b/pp.back.macos
@@ -151,6 +151,8 @@ pp_backend_macos_init () {
     pp_macos_bundle_version=
     pp_macos_bundle_info_string=
     pp_macos_pkg_type=bundle
+    pp_macos_pkg_background=
+    pp_macos_pkg_background_dark=
     pp_macos_pkg_license=
     pp_macos_pkg_readme=
     pp_macos_pkg_welcome=
@@ -760,6 +762,14 @@ pp_backend_macos_flat () {
     if test -n "$pp_macos_pkg_license"; then
 	cp -R "${pp_macos_pkg_license}" $Resources
 	echo "    <license file=\"${pp_macos_pkg_license##*/}\"/>" >>$pkgdir/Distribution
+    fi
+    if test -n "$pp_macos_pkg_background"; then
+	cp -R "${pp_macos_pkg_background}" $Resources
+	echo "    <background file=\"${pp_macos_pkg_background##*/}\" scaling=\"proportional\" alignment=\"left\"/>" >>$pkgdir/Distribution
+    fi
+    if test -n "$pp_macos_pkg_background_dark"; then
+	cp -R "${pp_macos_pkg_background_dark}" $Resources
+	echo "    <background-darkAqua file=\"${pp_macos_pkg_background_dark##*/}\" scaling=\"proportional\" alignment=\"left\"/>" >>$pkgdir/Distribution
     fi
     cat <<-. >>$pkgdir/Distribution
 	    <choices-outline>

--- a/pp.back.macos
+++ b/pp.back.macos
@@ -1,18 +1,24 @@
 # Macintosh OS X backend
 #
 # References:
-# http://developer.apple.com/documentation/DeveloperTools/Conceptual/SoftwareDistribution/index.html
-# http://mirrors-3v.club-internet.fr/mirrors/ftp.osxgnu.org/pub/osxgnu/OSXPM/package
-# http://developer.apple.com/releasenotes/DeveloperTools/Installer.html
-# Packagmeaker Help files
+# https://medium.com/swlh/the-easiest-way-to-build-macos-installer-for-your-application-34a11dd08744
+# https://developer.apple.com/library/archive/documentation/DeveloperTools/Reference/DistributionDefinitionRef/Chapters/Introduction.html
+# https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/PackageMakerUserGuide/Introduction/Introduction.html
+# The pkgbuild man page
 #
-# PolyPackage builds Mac OS package bundles (i.e. foo.pkg directories).
-# This is different from the "flat packages" introduced in Mac OS 10.5.
+# Obsolete references:
+# http://mirror.informatimago.com/next/developer.apple.com/documentation/DeveloperTools/Conceptual/SoftwareDistribution/index.html
+# http://mirror.informatimago.com/next/developer.apple.com/releasenotes/DeveloperTools/Installer.html
+# https://download.osxgnu.org/OSXPM/package
+#
+# PolyPackage builds Mac OS package bundles (i.e. foo.pkg directories)
+# by default.  This is different from the "flat packages" introduced in
+# Mac OS 10.5.  The pp_macos_pkg_type variable controls which type is built.
 # See http://s.sudre.free.fr/Stuff/Ivanhoe/FLAT.html for flat package details.
 # http://www.mactech.com/articles/mactech/Vol.26/26.02/TheFlatPackage/index.html
 #
 # For online update support, Apple keeps its 'softwareupdate' tool
-# for apple use only. However, see http://code.google.com/p/update-engine/
+# for apple use only. However, see https://code.google.com/p/update-engine/
 
 : NOTES <<.
 
@@ -62,7 +68,7 @@
 	/etc	root:admin 0755
 	/var    root:admin 0755
 
-    <http://developer.apple.com/documentation/DeveloperTools/Conceptual/SoftwareDistribution4/Concepts/sd_pkg_flags.html>
+    <http://mirror.informatimago.com/next/developer.apple.com/documentation/DeveloperTools/Conceptual/SoftwareDistribution/Concepts/sd_pkg_flags.html>
     Info.plist = {
      CFBundleGetInfoString: "1.2.3, One Identity LLC.",
      CFBundleIdentifier: "com.quest.rc.openssh",
@@ -97,7 +103,7 @@
 
  # Startup scripts
     'launchd' is a kind of combined inetd and rc/init.d system.
-    <http://developer.apple.com/documentation/MacOSX/Conceptual/BPSystemStartup/Articles/DesigningDaemons.html>
+    <https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/DesigningDaemons.html>
     Create a /Library/LaunchDaemons/$daemonname.plist file
     Examples found in /System/Library/LaunchDaemons/
     See manual page launchd.plist(5) for details:
@@ -744,7 +750,6 @@ pp_backend_macos_flat () {
     numfiles="${numfiles##* }"
 
     # Write Distribution file
-    # https://developer.apple.com/library/archive/documentation/DeveloperTools/Reference/DistributionDefinitionRef/Chapters/Introduction.html
     cat <<-. >$pkgdir/Distribution
 	<?xml version="1.0" encoding="UTF-8"?>
 	<installer-gui-script minSpecVersion="1">

--- a/pp.back.macos
+++ b/pp.back.macos
@@ -744,9 +744,10 @@ pp_backend_macos_flat () {
     numfiles="${numfiles##* }"
 
     # Write Distribution file
+    # https://developer.apple.com/library/archive/documentation/DeveloperTools/Reference/DistributionDefinitionRef/Chapters/Introduction.html
     cat <<-. >$pkgdir/Distribution
 	<?xml version="1.0" encoding="UTF-8"?>
-	<installer-script minSpecVersion="1.000000" authoringTool="com.quest.rc.PolyPkg" authoringToolVersion="$pp_version" authoringToolBuild="$pp_revision">
+	<installer-gui-script minSpecVersion="1">
 	    <title>$name $version</title>
 	    <options customize="never" allow-external-scripts="no"/>
 	    <domains enable_localSystem="true"/>
@@ -779,7 +780,7 @@ pp_backend_macos_flat () {
 	        <pkg-ref id="${pp_macos_bundle_id}"/>
 	    </choice>
 	    <pkg-ref id="${pp_macos_bundle_id}" installKBytes="$size" version="$version" auth="Root">#$pkgfile</pkg-ref>
-	</installer-script>
+	</installer-gui-script>
 .
 
     # write scripts archive


### PR DESCRIPTION
The pp_macos_pkg_background and pp_macos_pkg_background_dark settings can now be used to set the installer backgroup for light and dark mode. This PR also replaces "installer-script" with "installer-gui-script" to match the current documentation.