### PR TITLE
pp.back.systemd.svc: fix false detection of init.d/service status

### DIFF
--- a/pp.back.systemd.svc
+++ b/pp.back.systemd.svc
@@ -145,10 +145,18 @@ pp_systemd_service_install_common () {
                 # we do this so we do not "orphan" the process. Because init started it and if we enable systemd
                 # it will not know about this process and will not be able to stop it.
                 if [ -x "/etc/init.d/$svc" ]; then
-                    /etc/init.d/$svc status > /dev/null 2>&1
+                    output="$(/etc/init.d/$svc status 2>&1)"
                     RUNNING=$?
                     if [ $RUNNING -eq 0 ]; then
-                        /etc/init.d/$svc stop > /dev/null 2>&1
+                        case "$output" in
+                            *"not running"*)
+                                # systemd is reporting the status (compatibility package is installed)
+                                RUNNING=1
+                                ;;
+                            *)  # it is really running
+                                /etc/init.d/$svc stop > /dev/null 2>&1
+                                ;;
+                        esac
                     fi
                 else
                     RUNNING=1


### PR DESCRIPTION
Normal init.d status script returns with non zero if service is not running.
However, on sles12 at least, systemd status gets called instead, which
prints the info on the screen about service is not running and returns
with success (0).

This results in the service getting "restarted" even though it was not
running before.