### PR TITLE
Use the POSIX shell "command -v" instead of "which" to find programs.

### DIFF
--- a/pp.back.bsd
+++ b/pp.back.bsd
@@ -91,7 +91,7 @@ pp_bsd_check_required_programs () {
     # list of programs FreeBSD needs in order to create a binary package
     for prog in ${pp_bsd_required_programs:-"pkg"}
     do
-        if which $prog 2>&1 > /dev/null; then
+        if command -v $prog 2>&1 > /dev/null; then
             pp_debug "$prog: found"
         else
             pp_debug "$prog: not found"

--- a/pp.back.deb
+++ b/pp.back.deb
@@ -54,7 +54,7 @@ pp_deb_check_required_programs () {
     needed= notfound=
     for prog in dpkg dpkg-deb install md5sum fakeroot
     do
-        if which $prog 2>/dev/null >/dev/null; then
+        if command -v $prog 2>/dev/null >/dev/null; then
 	    pp_debug "$prog: found"
 	else
 	    pp_debug "$prog: not found"

--- a/pp.back.rpm
+++ b/pp.back.rpm
@@ -183,7 +183,7 @@ pp_rpm_detect_distro () {
 pp_rpm_detect_rpmbuild () {
     local cmd
     for cmd in rpmbuild rpm; do
-        if `which $cmd > /dev/null 2>&1`; then
+        if command -v $cmd > /dev/null 2>&1; then
             echo $cmd
             return 0
         fi


### PR DESCRIPTION
We should not rely on the "which" utility since it may not be present on all systems.  We can use "command" instead, which is a POSIX shell built-in that also exists in ksh.