### PR TITLE
DragonFly BSD also uses FreeBSD-style packages

### DIFF
--- a/pp.back.bsd
+++ b/pp.back.bsd
@@ -18,7 +18,7 @@ pp_bsd_munge_text () {
 
 #@ pp_backend_bsd_detect(): return true if this platform uses FreeBSD pkgs
 pp_backend_bsd_detect () {
-	test x"$1" = x"FreeBSD"
+    test x"$1" = x"FreeBSD" -o x"$1" = x"DragonFly"
 }
 
 #@ pp_backend_bsd_init(): initialize the bsd vars
@@ -27,7 +27,7 @@ pp_backend_bsd_init () {
     # Get the OS revision
     pp_bsd_detect_os
 
-    # Get the arch (i386/amd64)
+    # Get the arch (i386/x86_64)
     pp_bsd_detect_arch
 
     pp_bsd_name=
@@ -41,6 +41,13 @@ pp_backend_bsd_init () {
     pp_bsd_prefix="/usr/local/"
     pp_bsd_desc=
     pp_bsd_message=
+
+    # FreeBSD uses package.txz, DragonFly uses package.pkg.
+    if [ "$pp_bsd_os" = "DragonFly" ]; then
+        pp_bsd_pkg_sfx=pkg
+    else
+        pp_bsd_pkg_sfx=txz
+    fi
 
     # pp_bsd_category must be in array format comma separated
     # pp_bsd_category=[security,network]
@@ -122,7 +129,7 @@ pp_bsd_detect_os () {
 pp_bsd_detect_arch() {
     pp_bsd_platform="`uname -m`" 
     case $pp_bsd_platform in
-        amd64) pp_bsd_platform_std=x86_64;;
+        amd64|x86_64) pp_bsd_platform_std=x86_64;;
         i386)  pp_bsd_platform_std=i386;;
         *)     pp_bsd_platform_std=unknown;;
     esac
@@ -472,13 +479,13 @@ pp_backend_bsd() {
 #@ pp_bsd_name(component): print the name of the FreeBSD package files
 pp_bsd_name () {
     typeset cmp="${1:-run}"
-    echo `pp_bsd_cmp_full_name $cmp`"-${pp_bsd_version:-$version}.txz"
+    echo `pp_bsd_cmp_full_name $cmp`"-${pp_bsd_version:-$version}.${pp_bsd_pkg_sfx}"
 }
 
 #@ pp_backend_bsd_names(): print the names of the FreeBSD package files
 pp_backend_bsd_names () {
     for cmp in $pp_components; do
-    	echo `pp_bsd_cmp_full_name $cmp`"-${pp_bsd_version:-$version}.txz"
+    	echo `pp_bsd_cmp_full_name $cmp`"-${pp_bsd_version:-$version}.${pp_bsd_pkg_sfx}"
     done
 }
 
@@ -497,8 +504,8 @@ pp_backend_bsd_probe () {
 #@ pp_backend_bsd_vas_platforms(): print the VAS platform identifiers
 pp_backend_bsd_vas_platforms() {
     case "${pp_bsd_platform_std}" in
-        x86_64) echo "FreeBSD-x86_64.txz FreeBSD-i386.txz";;
-        i386)   echo "FreeBSD-i386.txz";;
+        x86_64) echo "FreeBSD-x86_64.${pp_bsd_pkg_sfx} FreeBSD-i386.${pp_bsd_pkg_sfx}";;
+        i386)   echo "FreeBSD-i386.${pp_bsd_pkg_sfx}";;
         *) pp_die "unknown architecture $pp_bsd_platform_std";;
     esac
 }

--- a/pp.back.bsd
+++ b/pp.back.bsd
@@ -322,8 +322,8 @@ pp_bsd_make_data() {
                             mkdir -p `dirname "$datadir$path"`
                         fi
 
-                        pp_debug "install -D $datadir -o $o -g $g -h sha256 -m ${m} -v $pp_destdir$p $datadir$path"
-                        pp_bsd_fakeroot install -D $datadir -o $o -g $g -h sha256 -m ${m} -v $pp_destdir$p $datadir$path
+                        pp_debug "install -D $datadir -o $o -g $g -m ${m} -v $pp_destdir$p $datadir$path"
+                        pp_bsd_fakeroot install -D $datadir -o $o -g $g -m ${m} -v $pp_destdir$p $datadir$path
                         echo "  \"$path\": \"-\", \"$path\": {uname: $o, gname: $g, perm: ${m}}" >> $outfilelist
                         ;; 
                 esac


### PR DESCRIPTION
The only real difference is that it used a .pkg suffix instead of .txf.