### PR TITLE
avoid shipping sysv init script in case systemd is detected

### DIFF
--- a/DOC
+++ b/DOC
@@ -307,7 +307,10 @@ The %files sections
 		s     mode owner group flags path target
 
 	Where d,f,s indicate directory, file or symbolic link.
-	The v field indicates volatility, or '-' for a placeholder.
+	The flags can be:
+		v flag indicates volatility,
+		m flag indicates missingok (do not warn if the file is missing during package removal)
+		or '-' for a placeholder.
 	The mode of symbolic links is ignored but written as 777.
 
 	The %fixup stage may be used to edit the %files components.

--- a/DOC.xml
+++ b/DOC.xml
@@ -357,7 +357,10 @@ description="Hello tool"
 		s     mode owner group flags path target
 
 	Where d,f,s indicate directory, file or symbolic link.
-	The v field indicates volatility, or '-' for a placeholder.
+	The flags can be:
+		v flag indicates volatility,
+		m flag indicates missingok (do not warn if the file is missing during package removal)
+		or '-' for a placeholder.
 	The mode of symbolic links is ignored but written as 777.
 
 	The %fixup stage may be used to edit the %files components.

--- a/pp.back.rpm
+++ b/pp.back.rpm
@@ -287,7 +287,10 @@ pp_rpm_writefiles () {
 	    test x"$farch" = x"noarch" || pp_add_to_list pp_rpm_arch_seen $farch
 	fi
 
-	case $f in *v*) _l="%config(noreplace) $_l";; esac
+	case $f in
+		*v*) _l="%config(noreplace) $_l";;
+		*m*) _l="%config(missingok) $_l";;
+	esac
 	echo "$_l"
     done
     echo

--- a/pp.back.rpm.svc
+++ b/pp.back.rpm.svc
@@ -144,7 +144,7 @@ pp_rpm_service_group_make_init_script () {
     local script=/etc/init.d/$grp
     local out=$pp_destdir$script
 
-    pp_add_file_if_missing $script run 755 || return 0
+    pp_add_file_if_missing $script run 755 m || return 0
 
     cat <<-. >>$out
 	#!/bin/sh
@@ -240,7 +240,7 @@ pp_rpm_service_make_service_files () {
     local out=$pp_destdir$script
     local _process _cmd _rpmlevels
 
-    pp_add_file_if_missing $script run 755 || return 0
+    pp_add_file_if_missing $script run 755 m || return 0
 
     #-- start out as an empty shell script
     cat <<-'.' >$out

--- a/pp.back.systemd.svc
+++ b/pp.back.systemd.svc
@@ -164,11 +164,16 @@ pp_systemd_service_install_common () {
 
                 # Enable the $svc.service
                 $systemctl_cmd daemon-reload >/dev/null 2>&1
+
+                # We do not need the init.d script any more, and it causes problems on SLES
+                # where systemd sysv compatibility is enforced and broken on default installs
+                rm -f "/etc/init.d/$svc"
+
                 $systemctl_cmd enable $svc.service >/dev/null 2>&1
 
                 # Now that the service has been enabled, start it again if it was running before.
                 if [ $RUNNING -eq 0 ]; then
-                    /etc/init.d/$svc start > /dev/null 2>&1
+                    $systemctl_cmd start $svc.service >/dev/null 2>&1
                 fi
             fi
         }

--- a/pp.back.systemd.svc
+++ b/pp.back.systemd.svc
@@ -240,6 +240,8 @@ pp_systemd_service_remove_common () {
                 _pp_systemd_init
             fi
 
+            $systemctl_cmd stop $svc.service > /dev/null 2>&1
+
             # Remove the systemd unit service file
             if [ "x$systemd_service_dir" != "x$systemd_system_unit_dir" ]; then
                 rm -f "$systemd_system_unit_dir/$svc.service"

--- a/pp.back.systemd.svc
+++ b/pp.back.systemd.svc
@@ -158,8 +158,15 @@ pp_systemd_service_install_common () {
                                 ;;
                         esac
                     fi
-                else
-                    RUNNING=1
+                fi
+
+                # If the service is not running according to its sysv script (eg. systemd service
+                # is not using a pidfile the sysv script needs), or its sysv script is not present any more,
+                # check how systemd thinks.
+                # We also try to restart the service in case something went wrong with it.
+                if $systemctl_cmd is-active "$svc" >/dev/null 2>&1 || $systemctl_cmd is-failed "$svc" >/dev/null 2>&1; then
+                        $systemctl_cmd stop "$svc" >/dev/null 2>&1
+                        RUNNING=0
                 fi
 
                 # Enable the $svc.service

--- a/pp.front
+++ b/pp.front
@@ -51,6 +51,7 @@
 #
 # The flags is either - or a sequence of letters. The letters mean:
 #     v  - the file is volatile, and expected to change content during use
+#     m  - missingok (do not warn if the file is missing during package removal)
 #
 
 pp_if_true=0

--- a/pp.model
+++ b/pp.model
@@ -74,7 +74,7 @@ pp_load_service_vars () {
 #@ pp_files_expand(path [m] [[u]:[g]] [f] [t]): expand to a file path
 #    writes multiple lines of the form
 #       type path mode owner group flags [target]
-#    flags contains the letter v if the file is volatile
+#    flags contains the letter v if the file is volatile, letter m for missingok
 pp_files_expand () {
     typeset _p _mode _group _owner _flags _path _optional _has_target _tree
     typeset _target _file _tgt _m _o _g _f _type _lm _ll _lo _lg _ls _lx


### PR DESCRIPTION
Some linux distros ship by default with broken systemd <-> sysv compatibility. On these, if the init.d script is also present, it prevents the systemd service to get enabled. Observed the problem at least on SLES 15 SP3, Suse Tumbleweed, Suse Leap. (On the other side, RHEL, debian do work correctly.)

The goal of this patch is to remove the sysv init script when the systemd service gets enabled.

Example error on SLES:
```
> sudo systemctl enable myservice
Synchronizing state of myservice.service with SysV service script with /usr/lib/systemd/systemd-sysv-install.
Executing: /usr/lib/systemd/systemd-sysv-install enable myservice
/sbin/insserv: No such file or directory
```

On Suse:
```
# systemctl enable myservice
Synchronizing state of vasd.service with SysV service script with /usr/lib/systemd/systemd-sysv-install.
Executing: /usr/lib/systemd/systemd-sysv-install enable myservice
ln -sf ../vasd /etc/init.d/rc2.d/S50myservice
ln: failed to create symbolic link '/etc/init.d/rc2.d/S50myservice': No such file or directory
```
