### PR TITLE
pp.model: missingok can be specified in .pp config for files

### DIFF
--- a/DOC
+++ b/DOC
@@ -282,6 +282,7 @@ The %files sections
 
 	'Flags' is a comma-delimited list of flags. Valid flags are:
 		volatile	- uninstall will ignore changes in the file
+		missingok	- uninstall will ignore if the file is missing (rpm only for now)
 		optional	- ignore if the path-glob matches nothing
 		symlink		- The file must be packaged as a symlink
                 ignore          - ignore this file (don't package it)

--- a/DOC.xml
+++ b/DOC.xml
@@ -344,6 +344,7 @@ description="Hello tool"
 
 	'Flags' is a comma-delimited list of flags. Valid flags are:
 		volatile	- uninstall will ignore changes in the file
+		missingok	- uninstall will ignore if the file is missing (rpm only for now)
 		optional	- ignore if the path-glob matches nothing
 		symlink		- a symlink target follows
 

--- a/pp.model
+++ b/pp.model
@@ -114,6 +114,7 @@ pp_files_expand () {
     if test $# -gt 0; then
         _a=`eval echo \"$1\"`
 	case ",$_a," in *,volatile,*) _flags="${_flags}v";; esac
+	case ",$_a," in *,missingok,*) _flags="${_flags}m";; esac
 	case ",$_a," in *,optional,*) _optional=true;; esac
 	case ",$_a," in *,symlink,*) _has_target=true;; esac
 	case ",$_a," in *,ignore-others,*) _flags="${_flags}i";; esac


### PR DESCRIPTION
Can be useful for example when the init.d script is not generated by pp or various other reasons.