### PR TITLE
pp.back.bsd: package file extension is now "pkg" instead of txz

### DIFF
--- a/pp.back.bsd
+++ b/pp.back.bsd
@@ -42,8 +42,8 @@ pp_backend_bsd_init () {
     pp_bsd_desc=
     pp_bsd_message=
 
-    # FreeBSD uses package.txz, DragonFly uses package.pkg.
-    if [ "$pp_bsd_os" = "DragonFly" ]; then
+    # Newer "pkg" (>=1.17.0) generates package.pkg, before that package.txz.
+    if pp_is_version_greater 1.17.0 "$(pkg --version)"; then
         pp_bsd_pkg_sfx=pkg
     else
         pp_bsd_pkg_sfx=txz

--- a/pp.util
+++ b/pp.util
@@ -546,3 +546,8 @@ pp_strip_binaries () {
 	pp_package_stripped_binaries
     fi
 }
+
+pp_is_version_greater () {
+  smaller_version="$(echo -e "$1\n$2" | sort -V | head -1)"
+  test x"$smaller_version" = x"$1"
+}


### PR DESCRIPTION
on FreeBSD >= 12.0