### PR TITLE
pp_backend_bsd_probe: print a single line, not two.

### DIFF
--- a/pp.back.bsd
+++ b/pp.back.bsd
@@ -496,7 +496,6 @@ pp_backend_bsd_cleanup () {
 
 #@ pp_backend_bsd_probe(): print the local platform's short name
 pp_backend_bsd_probe () {
-        echo "${pp_bsd_os}-${pp_bsd_platform_std}"
         echo "${pp_bsd_os}${pp_bsd_os_rev}-${pp_bsd_platform_std}"
 }
 


### PR DESCRIPTION
The FreeBSD proble function was printing two lines--one with the OS version and one without.  This looks like an oversight, all the other backends display a single line containing the OS name, OS version and CPU platform.