### PR TITLE
_pp_systemd_enable: initialize RUNNING to 0

### DIFF
--- a/pp.back.systemd.svc
+++ b/pp.back.systemd.svc
@@ -131,7 +131,7 @@ pp_systemd_service_install_common () {
 
         _pp_systemd_enable () {
             local svc="$1"
-            local RUNNING
+            local RUNNING=0
 
             # If $systemctl_cmd is not set, then call _pp_systemd_init. If still not
             # set, we do not know where the systemctl command is so do nothing;


### PR DESCRIPTION
Fixes a syntax error when the service is not running, e.g. service.postinst: 120: [: -eq: unexpected operator